### PR TITLE
Allow remote blocklist fetch

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -94,7 +94,7 @@
         }
     ],
     "content_security_policy": {
-        "extension_pages": "script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'self'; connect-src 'self' https://*.supabase.co;"
+        "extension_pages": "script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'self'; connect-src 'self' https://*.supabase.co https://raw.githubusercontent.com;"
     },
     "icons": {
         "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary
- permit the service worker to fetch remote blocklists by allowing https://raw.githubusercontent.com in the extension CSP

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f16476bac8331a50dbf380d9793ec